### PR TITLE
Disable online dependency fetch in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,9 @@ add_subdirectory(src/cbmpc/protocol)
 # ------------- Tests ---------------------------
 
 if(NOT IS_MACOS)
-  set(USE_FETCH_CONTENT true)
+  # Disable FetchContent to avoid network access during builds. Use vendored
+  # googletest instead.
+  set(USE_FETCH_CONTENT false)
 endif()
 
 if(BUILD_TESTS)


### PR DESCRIPTION
## Summary
- avoid network access during CMake configuration
- use vendored googletest instead of FetchContent

## Testing
- `cmake -B build/Release -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON`
- `cmake --build build/Release --target cbmpc_test_unit -- -j1` *(fails: No rule to make target `/usr/local/opt/openssl@3.2.0/lib64/libcrypto.a`)*